### PR TITLE
port ios library to os x library

### DIFF
--- a/src/Classes/QREncoder/QREncoderOSX.h
+++ b/src/Classes/QREncoder/QREncoderOSX.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2009
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Ported from http://github.com/whomwah/rqrcode
+// by Bill Jacobs.
+//
+
+#import "QRCorrectionLevel.h"
+
+@class QRMatrix;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+@interface QREncoderOSX : NSObject {
+  NSString*         _str;
+  QRCorrectionLevel _correctionLevel;
+  int               _size;
+  int               _pattern;
+  QRMatrix*         _matrix;
+}
+
++ (NSImage *)encode:(NSString *)str;
++ (NSImage *)encode:(NSString *)str scale:(int)scale;
++ (NSImage *)encode:(NSString *)str size:(int)size correctionLevel:(QRCorrectionLevel)level;
++ (NSImage *)encode:(NSString *)str size:(int)size correctionLevel:(QRCorrectionLevel)level scale:(int)scale;
+
+@end

--- a/src/Classes/QREncoderOSX.m
+++ b/src/Classes/QREncoderOSX.m
@@ -1,0 +1,961 @@
+/**
+ * Copyright 2009
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "QRBitBuffer.h"
+#import "QRMatrix.h"
+#import "QREncoderOSX.h"
+#import "QRMath.h"
+#import "QRPolynomial.h"
+#import "QRRSBlock.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark Tables and macros
+
+#define G15 (1 << 10 | 1 << 8 | 1 << 5 | 1 << 4 | 1 << 2 | 1 << 1 | 1 << 0)
+#define G15_MASK (1 << 14 | 1 << 12 | 1 << 10 | 1 << 4 | 1 << 1)
+#define G18 (1 << 12 | 1 << 11 | 1 << 10 | 1 << 9 | 1 << 8 | 1 << 5 | 1 << 2 | 1 << 0)
+
+static int PATTERN_POSITION_TABLE[][8] =
+  {{0, 0, 0, 0, 0, 0, 0, 0},
+  {6, 18, 0, 0, 0, 0, 0, 0},
+  {6, 22, 0, 0, 0, 0, 0, 0},
+  {6, 26, 0, 0, 0, 0, 0, 0},
+  {6, 30, 0, 0, 0, 0, 0, 0},
+  {6, 34, 0, 0, 0, 0, 0, 0},
+  {6, 22, 38, 0, 0, 0, 0, 0},
+  {6, 24, 42, 0, 0, 0, 0, 0},
+  {6, 26, 46, 0, 0, 0, 0, 0},
+  {6, 28, 50, 0, 0, 0, 0, 0},
+  {6, 30, 54, 0, 0, 0, 0, 0},
+  {6, 32, 58, 0, 0, 0, 0, 0},
+  {6, 34, 62, 0, 0, 0, 0, 0},
+  {6, 26, 46, 66, 0, 0, 0, 0},
+  {6, 26, 48, 70, 0, 0, 0, 0},
+  {6, 26, 50, 74, 0, 0, 0, 0},
+  {6, 30, 54, 78, 0, 0, 0, 0},
+  {6, 30, 56, 82, 0, 0, 0, 0},
+  {6, 30, 58, 86, 0, 0, 0, 0},
+  {6, 34, 62, 90, 0, 0, 0, 0},
+  {6, 28, 50, 72, 94, 0, 0, 0},
+  {6, 26, 50, 74, 98, 0, 0, 0},
+  {6, 30, 54, 78, 102, 0, 0, 0},
+  {6, 28, 54, 80, 106, 0, 0, 0},
+  {6, 32, 58, 84, 110, 0, 0, 0},
+  {6, 30, 58, 86, 114, 0, 0, 0},
+  {6, 34, 62, 90, 118, 0, 0, 0},
+  {6, 26, 50, 74, 98, 122, 0, 0},
+  {6, 30, 54, 78, 102, 126, 0, 0},
+  {6, 26, 52, 78, 104, 130, 0, 0},
+  {6, 30, 56, 82, 108, 134, 0, 0},
+  {6, 34, 60, 86, 112, 138, 0, 0},
+  {6, 30, 58, 86, 114, 142, 0, 0},
+  {6, 34, 62, 90, 118, 146, 0, 0},
+  {6, 30, 54, 78, 102, 126, 150, 0},
+  {6, 24, 50, 76, 102, 128, 154, 0},
+  {6, 28, 54, 80, 106, 132, 158, 0},
+  {6, 32, 58, 84, 110, 136, 162, 0},
+  {6, 26, 54, 82, 110, 138, 166, 0},
+  {6, 30, 58, 86, 114, 142, 170, 0}};
+
+
+static int RS_BLOCK_TABLE[][7] = {
+//1
+{1, 26, 19, 0, 0, 0, 0},
+{1, 26, 16, 0, 0, 0, 0},
+{1, 26, 13, 0, 0, 0, 0},
+{1, 26, 9, 0, 0, 0, 0},
+
+//2
+{1, 44, 34, 0, 0, 0, 0},
+{1, 44, 28, 0, 0, 0, 0},
+{1, 44, 22, 0, 0, 0, 0},
+{1, 44, 16, 0, 0, 0, 0},
+
+//3
+{1, 70, 55, 0, 0, 0, 0},
+{1, 70, 44, 0, 0, 0, 0},
+{2, 35, 17, 0, 0, 0, 0},
+{2, 35, 13, 0, 0, 0, 0},
+
+//4
+{1, 100, 80, 0, 0, 0, 0},
+{2, 50, 32, 0, 0, 0, 0},
+{2, 50, 24, 0, 0, 0, 0},
+{4, 25, 9, 0, 0, 0, 0},
+
+//5
+{1, 134, 108, 0, 0, 0, 0},
+{2, 67, 43, 0, 0, 0, 0},
+{2, 33, 15, 2, 34, 16, 0},
+{2, 33, 11, 2, 34, 12, 0},
+
+//6
+{2, 86, 68, 0, 0, 0, 0},
+{4, 43, 27, 0, 0, 0, 0},
+{4, 43, 19, 0, 0, 0, 0},
+{4, 43, 15, 0, 0, 0, 0},
+
+//7
+{2, 98, 78, 0, 0, 0, 0},
+{4, 49, 31, 0, 0, 0, 0},
+{2, 32, 14, 4, 33, 15, 0},
+{4, 39, 13, 1, 40, 14, 0},
+
+//8
+{2, 121, 97, 0, 0, 0, 0},
+{2, 60, 38, 2, 61, 39, 0},
+{4, 40, 18, 2, 41, 19, 0},
+{4, 40, 14, 2, 41, 15, 0},
+
+//9
+{2, 146, 116, 0, 0, 0, 0},
+{3, 58, 36, 2, 59, 37, 0},
+{4, 36, 16, 4, 37, 17, 0},
+{4, 36, 12, 4, 37, 13, 0},
+
+//10
+{2, 86, 68, 2, 87, 69, 0},
+{4, 69, 43, 1, 70, 44, 0},
+{6, 43, 19, 2, 44, 20, 0},
+{6, 43, 15, 2, 44, 16, 0},
+
+//11
+{4, 101, 81, 0, 0, 0, 0},
+{1, 80, 50, 4, 81, 51, 0},
+{4, 50, 22, 4, 51, 23, 0},
+{3, 36, 12, 8, 37, 13, 0},
+
+//12
+{2, 116, 92, 2, 117, 93, 0},
+{6, 58, 36, 2, 59, 37, 0},
+{4, 46, 20, 6, 47, 21, 0},
+{7, 42, 14, 4, 43, 15, 0},
+
+//13
+{4, 133, 107, 0, 0, 0, 0},
+{8, 59, 37, 1, 60, 38, 0},
+{8, 44, 20, 4, 45, 21, 0},
+{12, 33, 11, 4, 34, 12, 0},
+
+//14
+{3, 145, 115, 1, 146, 116, 0},
+{4, 64, 40, 5, 65, 41, 0},
+{11, 36, 16, 5, 37, 17, 0},
+{11, 36, 12, 5, 37, 13, 0},
+
+//15
+{5, 109, 87, 1, 110, 88, 0},
+{5, 65, 41, 5, 66, 42, 0},
+{5, 54, 24, 7, 55, 25, 0},
+{11, 36, 12, 0, 0, 0, 0},
+
+//16
+{5, 122, 98, 1, 123, 99, 0},
+{7, 73, 45, 3, 74, 46, 0},
+{15, 43, 19, 2, 44, 20, 0},
+{3, 45, 15, 13, 46, 16, 0},
+
+//17
+{1, 135, 107, 5, 136, 108, 0},
+{10, 74, 46, 1, 75, 47, 0},
+{1, 50, 22, 15, 51, 23, 0},
+{2, 42, 14, 17, 43, 15, 0},
+
+//18
+{5, 150, 120, 1, 151, 121, 0},
+{9, 69, 43, 4, 70, 44, 0},
+{17, 50, 22, 1, 51, 23, 0},
+{2, 42, 14, 19, 43, 15, 0},
+
+//19
+{3, 141, 113, 4, 142, 114, 0},
+{3, 70, 44, 11, 71, 45, 0},
+{17, 47, 21, 4, 48, 22, 0},
+{9, 39, 13, 16, 40, 14, 0},
+
+//20
+{3, 135, 107, 5, 136, 108, 0},
+{3, 67, 41, 13, 68, 42, 0},
+{15, 54, 24, 5, 55, 25, 0},
+{15, 43, 15, 10, 44, 16, 0},
+
+//21
+{4, 144, 116, 4, 145, 117, 0},
+{17, 68, 42, 0, 0, 0, 0},
+{17, 50, 22, 6, 51, 23, 0},
+{19, 46, 16, 6, 47, 17, 0},
+
+//22
+{2, 139, 111, 7, 140, 112, 0},
+{17, 74, 46, 0, 0, 0, 0},
+{7, 54, 24, 16, 55, 25, 0},
+{34, 37, 13, 0, 0, 0, 0},
+
+//23
+{4, 151, 121, 5, 152, 122, 0},
+{4, 75, 47, 14, 76, 48, 0},
+{11, 54, 24, 14, 55, 25, 0},
+{16, 45, 15, 14, 46, 16, 0},
+
+//24
+{6, 147, 117, 4, 148, 118, 0},
+{6, 73, 45, 14, 74, 46, 0},
+{11, 54, 24, 16, 55, 25, 0},
+{30, 46, 16, 2, 47, 17, 0},
+
+//25
+{8, 132, 106, 4, 133, 107, 0},
+{8, 75, 47, 13, 76, 48, 0},
+{7, 54, 24, 22, 55, 25, 0},
+{22, 45, 15, 13, 46, 16, 0},
+
+//26
+{10, 142, 114, 2, 143, 115, 0},
+{19, 74, 46, 4, 75, 47, 0},
+{28, 50, 22, 6, 51, 23, 0},
+{33, 46, 16, 4, 47, 17, 0},
+
+//27
+{8, 152, 122, 4, 153, 123, 0},
+{22, 73, 45, 3, 74, 46, 0},
+{8, 53, 23, 26, 54, 24, 0},
+{12, 45, 15, 28, 46, 16, 0},
+
+//28
+{3, 147, 117, 10, 148, 118, 0},
+{3, 73, 45, 23, 74, 46, 0},
+{4, 54, 24, 31, 55, 25, 0},
+{11, 45, 15, 31, 46, 16, 0},
+
+//29
+{7, 146, 116, 7, 147, 117, 0},
+{21, 73, 45, 7, 74, 46, 0},
+{1, 53, 23, 37, 54, 24, 0},
+{19, 45, 15, 26, 46, 16, 0},
+
+//30
+{5, 145, 115, 10, 146, 116, 0},
+{19, 75, 47, 10, 76, 48, 0},
+{15, 54, 24, 25, 55, 25, 0},
+{23, 45, 15, 25, 46, 16, 0},
+
+//31
+{13, 145, 115, 3, 146, 116, 0},
+{2, 74, 46, 29, 75, 47, 0},
+{42, 54, 24, 1, 55, 25, 0},
+{23, 45, 15, 28, 46, 16, 0},
+
+//32
+{17, 145, 115, 0, 0, 0, 0},
+{10, 74, 46, 23, 75, 47, 0},
+{10, 54, 24, 35, 55, 25, 0},
+{19, 45, 15, 35, 46, 16, 0},
+
+//33
+{17, 145, 115, 1, 146, 116, 0},
+{14, 74, 46, 21, 75, 47, 0},
+{29, 54, 24, 19, 55, 25, 0},
+{11, 45, 15, 46, 46, 16, 0},
+
+//34
+{13, 145, 115, 6, 146, 116, 0},
+{14, 74, 46, 23, 75, 47, 0},
+{44, 54, 24, 7, 55, 25, 0},
+{59, 46, 16, 1, 47, 17, 0},
+
+//35
+{12, 151, 121, 7, 152, 122, 0},
+{12, 75, 47, 26, 76, 48, 0},
+{39, 54, 24, 14, 55, 25, 0},
+{22, 45, 15, 41, 46, 16, 0},
+
+//36
+{6, 151, 121, 14, 152, 122, 0},
+{6, 75, 47, 34, 76, 48, 0},
+{46, 54, 24, 10, 55, 25, 0},
+{2, 45, 15, 64, 46, 16, 0},
+
+//37
+{17, 152, 122, 4, 153, 123, 0},
+{29, 74, 46, 14, 75, 47, 0},
+{49, 54, 24, 10, 55, 25, 0},
+{24, 45, 15, 46, 46, 16, 0},
+
+//38
+{4, 152, 122, 18, 153, 123, 0},
+{13, 74, 46, 32, 75, 47, 0},
+{48, 54, 24, 14, 55, 25, 0},
+{42, 45, 15, 32, 46, 16, 0},
+
+//39
+{20, 147, 117, 4, 148, 118, 0},
+{40, 75, 47, 7, 76, 48, 0},
+{43, 54, 24, 22, 55, 25, 0},
+{10, 45, 15, 67, 46, 16, 0},
+
+//40
+{19, 148, 118, 6, 149, 119, 0},
+{18, 75, 47, 31, 76, 48, 0},
+{34, 54, 24, 34, 55, 25, 0},
+{20, 45, 15, 61, 46, 16, 0}
+};
+
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
+@interface QREncoderOSX()
+- (void)encode;
+- (int)lostPoint;
+
+@end
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
+@implementation QREncoderOSX
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (id)initWithStr: (NSString*)str
+             size: (int)size
+  correctionLevel: (QRCorrectionLevel)correctionLevel
+          pattern: (int)pattern {
+
+  if (self = [super init]) {
+    _str              = [str copy];
+    _size             = size;
+    _correctionLevel  = correctionLevel;
+    _pattern          = pattern;
+
+    int matrixSize = 4 * _size + 17;
+    _matrix = [[QRMatrix alloc] initWithWidth:matrixSize height:matrixSize];
+  }
+
+  return self;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)dealloc {
+  [_str release];
+  [_matrix release];
+  [super dealloc];
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
+#pragma mark Global methods
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//TODO: Need to support actual image size, not just 'scale'
++ (NSImage *)imageForMatrix:(QRMatrix *)matrix scale:(int)scale{
+        
+  int width = scale*matrix.width;
+  int height = scale*matrix.height;
+  unsigned char *bytes = (unsigned char *)malloc(width * height * 4);
+  for(int y = 0; y < height; y++) {
+    for(int x = 0; x < width; x++) {
+      BOOL bit = [matrix getX:floor(x/scale) y:floor(y/scale)];
+      unsigned char intensity = bit ? 0 : 255;
+      for(int i = 0; i < 3; i++) {
+        bytes[y * width * 4 + x * 4 + i] = intensity;
+      }
+      bytes[y * width * 4 + x * 4 + 3] = 255;
+    }
+  }
+  
+  //int width = 32;
+  //int height = 32;
+  //unsigned char *bytes = (unsigned char *)malloc(width * height);
+  //memset(bytes, 255, width * height * 4);
+  
+  CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+  CGContextRef c = CGBitmapContextCreate(bytes, width, height, 8, 4 * width, colorSpace, kCGImageAlphaPremultipliedLast);
+  CFRelease(colorSpace);
+  CGImageRef image = CGBitmapContextCreateImage(c);
+  CFRelease(c);
+  NSImage *image2 = [[NSImage alloc] initWithCGImage:image size:NSSizeFromCGSize(CGSizeMake(width, height))];
+  CFRelease(image);
+  return image2;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//+ (UIImage *)imageForMatrix:(QRMatrix *)matrix{
+//    
+//    return [QREncoder imageForMatrix:matrix scale:1];
+//}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
++ (NSImage *)encode:(NSString *)str {
+    return [QREncoderOSX encode:str scale:1];
+}
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//TODO: Need to support actual image size, not just 'scale'
++ (NSImage *)encode:(NSString *)str scale:(int)scale {
+    return [QREncoderOSX encode:str size:4 correctionLevel:QRCorrectionLevelHigh scale:scale];
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
++ (NSImage *)encode:(NSString *)str size:(int)size correctionLevel:(QRCorrectionLevel)level {
+    return [QREncoderOSX encode:str size:size correctionLevel:level scale:1];
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
++ (NSImage *)encode:(NSString *)str size:(int)size correctionLevel:(QRCorrectionLevel)level scale:(int)scale{
+    QREncoderOSX *encoders[8];
+    for(int i = 0; i < 8; i++) {
+        encoders[i] = [[QREncoderOSX alloc] initWithStr:str size:size correctionLevel:level pattern:i];
+        [encoders[i] encode];
+    }
+    
+    long int minLostPoint = LONG_MAX;
+    QREncoderOSX *encoder = nil;
+    for(int i = 0; i < 8; i++) {
+        if (encoders[i]->_matrix != nil) {
+            int lostPoint = [encoders[i] lostPoint];
+            if (lostPoint < minLostPoint) {
+                minLostPoint = lostPoint;
+                encoder = encoders[i];
+            }
+        }
+    }
+    
+    NSImage *image;
+    if (encoder != nil) {
+        image = [QREncoderOSX imageForMatrix:encoder->_matrix scale:scale];
+    } else {
+        image = nil;
+    }
+    
+    for(int i = 0; i < 8; i++) {
+        [encoders[i] release];
+    }
+    
+    return image;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setupPositionProbePatternAtRow:(int)row column:(int)col {
+  for(int r = -1; r <= 7; r++) {
+    if (row + r < 0 || row + r >= _matrix.height) {
+      continue;
+    }
+
+    for(int c = -1; c <= 7; c++) {
+      if (col + c < 0 || col + c >= _matrix.width) {
+        continue;
+      }
+
+      BOOL bit = (r >= 0 && r <= 6 && (c == 0 || c == 6)) || 
+        (c >= 0 && c <= 6 && (r == 0 || r == 6)) ||
+        (r >= 2 && r <= 4 && c >= 2 && c <= 4);
+      [_matrix setX:col + c y:row + r value:bit];
+    }
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setupPositionAdjustPattern {
+  int *patterns = PATTERN_POSITION_TABLE[_size - 1];
+
+  for(int  i = 0; patterns[i] != 0; i++) {
+    int row = patterns[i];
+
+    for(int j = 0; patterns[j] != 0; j++) {
+      int col = patterns[j];
+      if ([_matrix hasSetX:col y:row]) {
+        continue;
+      }
+
+      for(int r = -2; r <= 2; r++) {
+        for(int c = -2; c <= 2; c++) {
+          BOOL bit = ABS(r) == 2 || ABS(c) == 2 || (r == 0 && c == 0);
+          [_matrix setX:col + c y:row + r value:bit];
+        }
+      }
+    }
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setupTimingPattern {
+  for(int i = 8; i < _matrix.width - 8; i++) {
+    [_matrix setX:i y:6 value:i % 2 == 0];
+    [_matrix setX:6 y:i value:i % 2 == 0];
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (int)getBchDigit:(int)data {
+  int digit = 0;
+  while (data != 0) {
+    digit++;
+    data >>= 1;
+  }
+  return digit;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (int)getBchTypeInfo:(int)data {
+  int d = data << 10;
+
+  while ([self getBchDigit:d] >= [self getBchDigit:G15]) {
+    d ^= G15 << ([self getBchDigit:d] - [self getBchDigit:G15]);
+  }
+
+  return ((data << 10) | d) ^ G15_MASK;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (int)getBchTypeNumber:(int)data {
+  int d = data << 12;
+
+  while ([self getBchDigit:d] >= [self getBchDigit:G18]) {
+    d ^= (G18 << ([self getBchDigit:d] - [self getBchDigit:G18]));
+  }
+
+  return (data << 12) | d;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (int)correctionLevelNum {
+  switch (_correctionLevel) {
+    case QRCorrectionLevelLow:
+      return 1;
+    case QRCorrectionLevelMedium:
+      return 0;
+    case QRCorrectionLevelQ:
+      return 3;
+    case QRCorrectionLevelHigh:
+      return 2;
+    default:
+      NSAssert(NO, @"Unknown correction level");
+      return 0;
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setupTypeInfo {
+  int data = ([self correctionLevelNum] << 3) | _pattern;
+  int bits = [self getBchTypeInfo:data];
+  
+  for(int i = 0; i < 15; i++) {
+    BOOL bit = ((bits >> i) & 1) == 1;
+    
+    // Vertical
+    if (i < 6) {
+      [_matrix setX:8 y:i value:bit];
+    } else if (i < 8) {
+      [_matrix setX:8 y:i + 1 value:bit];
+    } else {
+      [_matrix setX:8 y:_matrix.height - 15 + i value:bit];
+    }
+    
+    // Horizontal
+    if (i < 8) {
+      [_matrix setX:_matrix.width - i - 1 y:8 value:bit];
+    } else if (i < 9) {
+      [_matrix setX:15 - i y:8 value:bit];
+    } else {
+      [_matrix setX:14 - i y:8 value:bit];
+    }
+  }
+  
+  // Fixed module
+  [_matrix setX:8 y:_matrix.height - 8 value:YES];
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)setupTypeNumber {
+  int bits = [self getBchTypeNumber:_size];
+  for(int i = 0; i < 18; i++) {
+    BOOL bit = ((bits >> i) & 1) == 1;
+    [_matrix setX:i % 3 + _matrix.width - 11 y:i / 3 value:bit];
+    [_matrix setX:i / 3 y:i % 3 + _matrix.width - 11 value:bit];
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (int *)getRSBlockTable {
+  int offset = [self correctionLevelNum];
+  switch (_correctionLevel) {
+    case QRCorrectionLevelLow:
+      offset = 0;
+      break;
+    case QRCorrectionLevelMedium:
+      offset = 1;
+      break;
+    case QRCorrectionLevelQ:
+      offset = 2;
+      break;
+    case QRCorrectionLevelHigh:
+      offset = 3;
+      break;
+    default:
+      NSAssert(NO, @"Unknown correction level");
+      offset = 0;
+      break;
+  }
+
+  return RS_BLOCK_TABLE[4 * (_size - 1) + offset];
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSArray *)getRSBlocks {
+  NSMutableArray *blocks = [[NSMutableArray alloc] init];
+  int *block = [self getRSBlockTable];
+  for(int i = 0; i == 0 || block[i - 2] != 0; i += 3) {
+    QRRSBlock *block2 = [[QRRSBlock alloc] initWithTotalCount:block[i + 1] dataCount:block[i + 2]];
+    for(int j = 0; j < block[i]; j++) {
+      [blocks addObject:block2];
+    }
+    [block2 release];
+  }
+  return [blocks autorelease];
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (QRBitBuffer *)getData {
+  QRBitBuffer *buffer = [[QRBitBuffer alloc] init];
+  [buffer append:4 length:4];
+  [buffer append:(int)[_str length] length:8];
+
+  for(int i = 0; i < [_str length]; i++) {
+    unichar c = [_str characterAtIndex:i];
+    if (c >= 256) {
+      [buffer release];
+      return nil;
+    }
+    [buffer append:c length:8];
+  }
+  
+  NSArray *rsBlocks = [self getRSBlocks];
+  int totalDataCount = 0;
+
+  for(QRRSBlock *rsBlock in rsBlocks) {
+    totalDataCount += rsBlock.dataCount;
+  }
+
+  if (buffer.numBits > totalDataCount * 8) {
+    //Code overflow
+    [buffer release];
+    return nil;
+  }
+
+  if (buffer.numBits + 4 <= totalDataCount * 8) {
+    [buffer append:0 length:4];
+  }
+
+  while (buffer.numBits % 8 != 0) {
+    [buffer append:NO];
+  }
+
+  while (YES) {
+    if (buffer.numBits >= totalDataCount * 8) {
+      break;
+    }
+    [buffer append:0xEC length:8];
+    if (buffer.numBits >= totalDataCount * 8) {
+      break;
+    }
+    [buffer append:0x11 length:8];
+  }
+
+  return buffer;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (QRPolynomial *)errorCorrectPolynomial:(int)length {
+  int cs[2] = {1, 0};
+
+  QRPolynomial *p = [[[QRPolynomial alloc] initWithCoeffs:cs length:1 shift:0] autorelease];
+
+  for(int i = 0; i < length; i++) {
+    cs[1] = [QRMath exp:i];
+    QRPolynomial *p2 = [[QRPolynomial alloc] initWithCoeffs:cs length:2 shift:0];
+    p = [p multiply:p2];
+    [p2 release];
+  }
+
+  return p;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (int *)computeBytes:(QRBitBuffer *)data size:(int *)resultSize {
+  NSArray *rsBlocks = [self getRSBlocks];
+  int offset = 0;
+  int maxDCCount = 0;
+  int maxECCount = 0;
+  int **dcData = (int **)malloc([rsBlocks count] * sizeof(int *));
+  int **ecData = (int **)malloc([rsBlocks count] * sizeof(int *));
+  int *ecCounts = (int *)malloc([rsBlocks count] * sizeof(int));
+  for(int r = 0; r < [rsBlocks count]; r++) {
+    QRRSBlock *rsBlock = [rsBlocks objectAtIndex:r];
+    int dcCount = rsBlock.dataCount;
+    int ecCount = rsBlock.totalCount - dcCount;
+    maxDCCount = MAX(maxDCCount, dcCount);
+    maxECCount = MAX(maxECCount, ecCount);
+    
+    int *buffer = (int *)malloc(dcCount * sizeof(int));
+    memset(buffer, 0, dcCount * sizeof(int));
+    for(int i = 0; i < 8 * dcCount; i++) {
+      if ([data get:i + 8 * offset])
+        buffer[i / 8] |= 1 << (7 - (i % 8));
+    }
+    offset += dcCount;
+    dcData[r] = buffer;
+    
+    QRPolynomial *rsPoly = [self errorCorrectPolynomial:ecCount];
+    QRPolynomial *rawPoly =
+      [[QRPolynomial alloc] initWithCoeffs:buffer
+                      length:dcCount
+                       shift:rsPoly.length - 1];
+    QRPolynomial *modPoly = [rawPoly mod:rsPoly];
+    
+    int length = rsPoly.length - 1;
+    ecCounts[r] = length;
+    int *es = (int *)malloc(length * sizeof(int));
+    for(int i = 0; i < length; i++) {
+      int modIndex = i + modPoly.length - length;
+      es[i] = modIndex >= 0 ? [modPoly get:modIndex] : 0;
+    }
+    ecData[r] = es;
+  }
+  
+  int totalCodeCount = 0;
+  for(QRRSBlock *rsBlock in rsBlocks)
+    totalCodeCount += rsBlock.totalCount;
+  
+  *resultSize = totalCodeCount;
+  int *data2 = (int *)malloc(totalCodeCount * sizeof(int));
+  int index = 0;
+  for(int i = 0; i < maxDCCount; i++) {
+    for(int r = 0; r < [rsBlocks count]; r++) {
+      QRRSBlock *rsBlock = [rsBlocks objectAtIndex:r];
+      if (i < rsBlock.dataCount) {
+        data2[index] = dcData[r][i];
+        index++;
+      }
+    }
+  }
+  
+  for(int i = 0; i < maxECCount; i++) {
+    for(int r = 0; r < [rsBlocks count]; r++) {
+      if (i < ecCounts[r]) {
+        data2[index] = ecData[r][i];
+        index++;
+      }
+    }
+  }
+  
+  for(int i = 0; i < [rsBlocks count]; i++) {
+    free(dcData[i]);
+    free(ecData[i]);
+  }
+  free(dcData);
+  free(ecData);
+  free(ecCounts);
+  
+  return data2;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (BOOL)maskForRow:(int)i col:(int)j {
+  switch (_pattern) {
+    case 0:
+      return (i + j) % 2 == 0;
+    case 1:
+      return i % 2 == 0;
+    case 2:
+      return j % 3 == 0;
+    case 3:
+      return (i + j) % 3 == 0;
+    case 4:
+      return ((i / 2) + (j / 3)) % 2 == 0;
+    case 5:
+      return (i * j) % 2 + (i * j) % 3 == 0;
+    case 6:
+      return ((i * j) % 2 + (i * j) % 3) % 2 == 0;
+    case 7:
+      return ((i * j) % 3 + (i * j) % 2) % 2 == 0;
+    default:
+      NSAssert(NO, @"Unknown pattern");
+      return NO;
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)mapData:(int *)bytes size:(int)dataSize {
+  int inc = -1;
+  int row = _matrix.height - 1;
+  int bitIndex = 7;
+  int byteIndex = 0;
+  for(int col2 = _matrix.width - 1; col2 >= 1; col2 -= 2) {
+    int col;
+    if (col2 > 6) {
+      col = col2;
+    } else {
+      col = col2 - 1;
+    }
+
+    while (YES) {
+      for(int c = 0; c < 2; c++) {
+        if (![_matrix hasSetX:col - c y:row]) {
+          BOOL bit = NO;
+          if (byteIndex < dataSize) {
+            bit = ((bytes[byteIndex] >> bitIndex) & 1) == 1;
+          }
+          if ([self maskForRow:row col:col - c]) {
+            bit = !bit;
+          }
+          [_matrix setX:col - c y:row value:bit];
+          if (bitIndex == 0) {
+            byteIndex++;
+            bitIndex = 7;
+          }
+          else {
+            bitIndex--;
+          }
+        }
+      }
+      
+      row += inc;
+      if (row < 0 || row >= _matrix.height) {
+        row -= inc;
+        inc = -inc;
+        break;
+      }
+    }
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)encode {
+  [self setupPositionProbePatternAtRow:0 column:0];
+  [self setupPositionProbePatternAtRow:_matrix.height - 7 column:0];
+  [self setupPositionProbePatternAtRow:0 column:_matrix.width - 7];
+  [self setupPositionAdjustPattern];
+  [self setupTypeInfo];
+  [self setupTimingPattern];
+  if (_pattern >= 7) {
+    [self setupTypeNumber];
+  }
+  QRBitBuffer *data = [self getData];
+  if (data == nil) {
+    // Code overflow
+    [_matrix release];
+    _matrix = nil;
+
+  } else {
+    int dataSize = 0;
+    int *bytes = [self computeBytes:data size:&dataSize];
+    [self mapData:bytes size:dataSize];
+    free(bytes);
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+- (int)lostPoint {
+  int lostPoint = 0;
+  
+  //Level 1
+  for(int row = 0; row < _matrix.height; row++) {
+    for(int col = 0; col < _matrix.width; col++) {
+      int sameCount = 0;
+      BOOL bit = [_matrix getX:col y:row];
+      for(int r = -1; r <= 1; r++) {
+        if (row + r < 0 || row + r >= _matrix.height) {
+          continue;
+        }
+        for(int c = -1; c <= 1; c++) {
+          if (col + c < 0 || col + c >= _matrix.height) {
+            continue;
+          }
+          if (bit == [_matrix getX:col + c y:row + r]) {
+            sameCount++;
+          }
+        }
+      }
+      if (sameCount > 5) {
+        lostPoint += sameCount - 2;
+      }
+    }
+  }
+  
+  //Level 2
+  for(int row = 0; row < _matrix.height - 1; row++) {
+    for(int col = 0; col < _matrix.width - 1; col++) {
+      int count = 0;
+
+      for(int r = 0; r < 1; r++) {
+        for(int c = 0; c < 1; c++) {
+          if ([_matrix getX:col + c y:row + r]) {
+            count++;
+          }
+        }
+      }
+
+      if (count == 0 || count == 4) {
+        lostPoint += 3;
+      }
+    }
+  }
+  
+  //Level 3
+  for(int row = 0; row < _matrix.height - 6; row++) {
+    for(int col = 0; col < _matrix.width; col++) {
+      if ([_matrix getX:col y:row] &&
+          ![_matrix getX:col y:row + 1] &&
+          [_matrix getX:col y:row + 2] &&
+          [_matrix getX:col y:row + 3] &&
+          ![_matrix getX:col y:row + 4] &&
+          [_matrix getX:col y:row + 5]) {
+        lostPoint += 40;
+      }
+    }
+  }
+  
+  return lostPoint * 10;
+}
+
+@end

--- a/src/QREncoder.xcodeproj/project.pbxproj
+++ b/src/QREncoder.xcodeproj/project.pbxproj
@@ -7,6 +7,22 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8F8E88BA1A2F2F110032ECA9 /* libQREncoderOSX.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F8E88AF1A2F2F110032ECA9 /* libQREncoderOSX.a */; };
+		8F8E88C71A2F2F570032ECA9 /* QREncoderOSX_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 8F8E88C61A2F2F570032ECA9 /* QREncoderOSX_Prefix.pch */; };
+		8F8E88CC1A2F2FEB0032ECA9 /* QRBitBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = EB7DA33110A4F1840071984A /* QRBitBuffer.h */; };
+		8F8E88CD1A2F2FEB0032ECA9 /* QRMatrix.h in Headers */ = {isa = PBXBuildFile; fileRef = EB7DA33310A4F1840071984A /* QRMatrix.h */; };
+		8F8E88CE1A2F2FEB0032ECA9 /* QRMath.h in Headers */ = {isa = PBXBuildFile; fileRef = EB7DA33910A4F1840071984A /* QRMath.h */; };
+		8F8E88CF1A2F2FEB0032ECA9 /* QRPolynomial.h in Headers */ = {isa = PBXBuildFile; fileRef = EB7DA33B10A4F1840071984A /* QRPolynomial.h */; };
+		8F8E88D01A2F2FEB0032ECA9 /* QRRSBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = EB7DA33D10A4F1840071984A /* QRRSBlock.h */; };
+		8F8E88D11A2F2FEB0032ECA9 /* QRCorrectionLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = EB7DA33610A4F1840071984A /* QRCorrectionLevel.h */; };
+		8F8E88D21A2F2FFF0032ECA9 /* QRBitBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = EB7DA33210A4F1840071984A /* QRBitBuffer.m */; };
+		8F8E88D31A2F2FFF0032ECA9 /* QRMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = EB7DA33410A4F1840071984A /* QRMatrix.m */; };
+		8F8E88D41A2F2FFF0032ECA9 /* QRMath.m in Sources */ = {isa = PBXBuildFile; fileRef = EB7DA33A10A4F1840071984A /* QRMath.m */; };
+		8F8E88D51A2F2FFF0032ECA9 /* QRPolynomial.m in Sources */ = {isa = PBXBuildFile; fileRef = EB7DA33C10A4F1840071984A /* QRPolynomial.m */; };
+		8F8E88D61A2F2FFF0032ECA9 /* QRRSBlock.m in Sources */ = {isa = PBXBuildFile; fileRef = EB7DA33E10A4F1840071984A /* QRRSBlock.m */; };
+		8F8E88D81A2F300A0032ECA9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F8E88D71A2F300A0032ECA9 /* Foundation.framework */; };
+		8F8E892D1A2F39920032ECA9 /* QREncoderOSX.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F8E892C1A2F39920032ECA9 /* QREncoderOSX.h */; };
+		8F8E892F1A2F39A30032ECA9 /* QREncoderOSX.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F8E892E1A2F39A30032ECA9 /* QREncoderOSX.m */; };
 		AACBBE4A0F95108600F1A2B1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AACBBE490F95108600F1A2B1 /* Foundation.framework */; };
 		EB7DA2E710A4ECE30071984A /* QREncoder_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = EB7DA2E610A4ECE30071984A /* QREncoder_Prefix.pch */; };
 		EB7DA33F10A4F1840071984A /* QRBitBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = EB7DA33110A4F1840071984A /* QRBitBuffer.h */; };
@@ -32,7 +48,24 @@
 		EB7DA44010A4F9E00071984A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB7DA43F10A4F9E00071984A /* CoreGraphics.framework */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		8F8E88BB1A2F2F110032ECA9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8F8E88AE1A2F2F110032ECA9;
+			remoteInfo = QREncoderOSX;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		8F8E88AF1A2F2F110032ECA9 /* libQREncoderOSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libQREncoderOSX.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8F8E88B91A2F2F110032ECA9 /* QREncoderOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QREncoderOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8F8E88BF1A2F2F110032ECA9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8F8E88C61A2F2F570032ECA9 /* QREncoderOSX_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QREncoderOSX_Prefix.pch; sourceTree = "<group>"; };
+		8F8E88D71A2F300A0032ECA9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		8F8E892C1A2F39920032ECA9 /* QREncoderOSX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = QREncoderOSX.h; path = Classes/QREncoder/QREncoderOSX.h; sourceTree = SOURCE_ROOT; };
+		8F8E892E1A2F39A30032ECA9 /* QREncoderOSX.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = QREncoderOSX.m; path = Classes/QREncoderOSX.m; sourceTree = SOURCE_ROOT; };
 		AACBBE490F95108600F1A2B1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		D2AAC07E0554694100DB518D /* libQREncoder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libQREncoder.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB7DA2E610A4ECE30071984A /* QREncoder_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QREncoder_Prefix.pch; sourceTree = "<group>"; };
@@ -57,6 +90,22 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		8F8E88AC1A2F2F110032ECA9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8F8E88D81A2F300A0032ECA9 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8F8E88B61A2F2F110032ECA9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8F8E88BA1A2F2F110032ECA9 /* libQREncoderOSX.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D2AAC07C0554694100DB518D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -81,6 +130,8 @@
 			children = (
 				D2AAC07E0554694100DB518D /* libQREncoder.a */,
 				EB7DA3AE10A4F5D90071984A /* QREncoderTest.octest */,
+				8F8E88AF1A2F2F110032ECA9 /* libQREncoderOSX.a */,
+				8F8E88B91A2F2F110032ECA9 /* QREncoderOSXTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -91,6 +142,8 @@
 				EB7DA3C610A4F6290071984A /* Tests */,
 				08FB77AEFE84172EC02AAC07 /* Encoder */,
 				32C88DFF0371C24200C91783 /* Other Sources */,
+				8F8E88B01A2F2F110032ECA9 /* QREncoderOSX */,
+				8F8E88BD1A2F2F110032ECA9 /* QREncoderOSXTests */,
 				0867D69AFE84028FC02AAC07 /* Frameworks */,
 				034768DFFF38A50411DB9C8B /* Products */,
 				EB7DA3AF10A4F5D90071984A /* QREncoderTest-Info.plist */,
@@ -102,6 +155,7 @@
 		0867D69AFE84028FC02AAC07 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8F8E88D71A2F300A0032ECA9 /* Foundation.framework */,
 				AACBBE490F95108600F1A2B1 /* Foundation.framework */,
 			);
 			name = Frameworks;
@@ -122,8 +176,34 @@
 			isa = PBXGroup;
 			children = (
 				EB7DA2E610A4ECE30071984A /* QREncoder_Prefix.pch */,
+				8F8E88C61A2F2F570032ECA9 /* QREncoderOSX_Prefix.pch */,
 			);
 			name = "Other Sources";
+			sourceTree = "<group>";
+		};
+		8F8E88B01A2F2F110032ECA9 /* QREncoderOSX */ = {
+			isa = PBXGroup;
+			children = (
+				8F8E892C1A2F39920032ECA9 /* QREncoderOSX.h */,
+				8F8E892E1A2F39A30032ECA9 /* QREncoderOSX.m */,
+			);
+			path = QREncoderOSX;
+			sourceTree = "<group>";
+		};
+		8F8E88BD1A2F2F110032ECA9 /* QREncoderOSXTests */ = {
+			isa = PBXGroup;
+			children = (
+				8F8E88BE1A2F2F110032ECA9 /* Supporting Files */,
+			);
+			path = QREncoderOSXTests;
+			sourceTree = "<group>";
+		};
+		8F8E88BE1A2F2F110032ECA9 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				8F8E88BF1A2F2F110032ECA9 /* Info.plist */,
+			);
+			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
 		EB7DA15D10A4DCD50071984A /* Maths */ = {
@@ -155,6 +235,21 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		8F8E88AD1A2F2F110032ECA9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8F8E88CC1A2F2FEB0032ECA9 /* QRBitBuffer.h in Headers */,
+				8F8E88CD1A2F2FEB0032ECA9 /* QRMatrix.h in Headers */,
+				8F8E88CE1A2F2FEB0032ECA9 /* QRMath.h in Headers */,
+				8F8E88CF1A2F2FEB0032ECA9 /* QRPolynomial.h in Headers */,
+				8F8E88D01A2F2FEB0032ECA9 /* QRRSBlock.h in Headers */,
+				8F8E88D11A2F2FEB0032ECA9 /* QRCorrectionLevel.h in Headers */,
+				8F8E892D1A2F39920032ECA9 /* QREncoderOSX.h in Headers */,
+				8F8E88C71A2F2F570032ECA9 /* QREncoderOSX_Prefix.pch in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D2AAC07A0554694100DB518D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -173,6 +268,41 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		8F8E88AE1A2F2F110032ECA9 /* QREncoderOSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8F8E88C41A2F2F110032ECA9 /* Build configuration list for PBXNativeTarget "QREncoderOSX" */;
+			buildPhases = (
+				8F8E88AB1A2F2F110032ECA9 /* Sources */,
+				8F8E88AC1A2F2F110032ECA9 /* Frameworks */,
+				8F8E88AD1A2F2F110032ECA9 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = QREncoderOSX;
+			productName = QREncoderOSX;
+			productReference = 8F8E88AF1A2F2F110032ECA9 /* libQREncoderOSX.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		8F8E88B81A2F2F110032ECA9 /* QREncoderOSXTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8F8E88C51A2F2F110032ECA9 /* Build configuration list for PBXNativeTarget "QREncoderOSXTests" */;
+			buildPhases = (
+				8F8E88B51A2F2F110032ECA9 /* Sources */,
+				8F8E88B61A2F2F110032ECA9 /* Frameworks */,
+				8F8E88B71A2F2F110032ECA9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8F8E88BC1A2F2F110032ECA9 /* PBXTargetDependency */,
+			);
+			name = QREncoderOSXTests;
+			productName = QREncoderOSXTests;
+			productReference = 8F8E88B91A2F2F110032ECA9 /* QREncoderOSXTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		D2AAC07D0554694100DB518D /* QREncoder */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB921E08733DC00010E9CD /* Build configuration list for PBXNativeTarget "QREncoder" */;
@@ -206,7 +336,7 @@
 			name = QREncoderTest;
 			productName = QREncoderTest;
 			productReference = EB7DA3AE10A4F5D90071984A /* QREncoderTest.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.ocunit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -215,6 +345,14 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0500;
+				TargetAttributes = {
+					8F8E88AE1A2F2F110032ECA9 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+					8F8E88B81A2F2F110032ECA9 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
 			};
 			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "QREncoder" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -230,11 +368,20 @@
 			targets = (
 				D2AAC07D0554694100DB518D /* QREncoder */,
 				EB7DA3AD10A4F5D90071984A /* QREncoderTest */,
+				8F8E88AE1A2F2F110032ECA9 /* QREncoderOSX */,
+				8F8E88B81A2F2F110032ECA9 /* QREncoderOSXTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		8F8E88B71A2F2F110032ECA9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EB7DA3A910A4F5D90071984A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -261,6 +408,26 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		8F8E88AB1A2F2F110032ECA9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8F8E88D21A2F2FFF0032ECA9 /* QRBitBuffer.m in Sources */,
+				8F8E88D31A2F2FFF0032ECA9 /* QRMatrix.m in Sources */,
+				8F8E88D41A2F2FFF0032ECA9 /* QRMath.m in Sources */,
+				8F8E88D51A2F2FFF0032ECA9 /* QRPolynomial.m in Sources */,
+				8F8E892F1A2F39A30032ECA9 /* QREncoderOSX.m in Sources */,
+				8F8E88D61A2F2FFF0032ECA9 /* QRRSBlock.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8F8E88B51A2F2F110032ECA9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D2AAC07B0554694100DB518D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -289,6 +456,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		8F8E88BC1A2F2F110032ECA9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8F8E88AE1A2F2F110032ECA9 /* QREncoderOSX */;
+			targetProxy = 8F8E88BB1A2F2F110032ECA9 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		1DEB921F08733DC00010E9CD /* Debug */ = {
@@ -331,6 +506,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
@@ -344,9 +520,176 @@
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
 				SDKROOT = iphoneos;
+			};
+			name = Release;
+		};
+		8F8E88C01A2F2F110032ECA9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = QREncoderOSX_Prefix.pch;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		8F8E88C11A2F2F110032ECA9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXECUTABLE_PREFIX = lib;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = QREncoderOSX_Prefix.pch;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		8F8E88C21A2F2F110032ECA9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = QREncoderOSXTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		8F8E88C31A2F2F110032ECA9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = QREncoderOSXTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -427,6 +770,24 @@
 			buildConfigurations = (
 				1DEB922308733DC00010E9CD /* Debug */,
 				1DEB922408733DC00010E9CD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8F8E88C41A2F2F110032ECA9 /* Build configuration list for PBXNativeTarget "QREncoderOSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8F8E88C01A2F2F110032ECA9 /* Debug */,
+				8F8E88C11A2F2F110032ECA9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8F8E88C51A2F2F110032ECA9 /* Build configuration list for PBXNativeTarget "QREncoderOSXTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8F8E88C21A2F2F110032ECA9 /* Debug */,
+				8F8E88C31A2F2F110032ECA9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/src/QREncoder.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/src/QREncoder.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:QREncoder.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/src/QREncoder.xcodeproj/project.xcworkspace/xcshareddata/QREncoder.xccheckout
+++ b/src/QREncoder.xcodeproj/project.xcworkspace/xcshareddata/QREncoder.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>AA005888-B0E0-48B9-BC7E-0005965DF267</string>
+	<key>IDESourceControlProjectName</key>
+	<string>QREncoder</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>3605186D57A54EF3EC8A6C5E847BA4D3BBB4F532</key>
+		<string>github.com:AustinChou/ObjQREncoder.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>src/QREncoder.xcodeproj</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>3605186D57A54EF3EC8A6C5E847BA4D3BBB4F532</key>
+		<string>../../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>github.com:AustinChou/ObjQREncoder.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>111</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>3605186D57A54EF3EC8A6C5E847BA4D3BBB4F532</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>3605186D57A54EF3EC8A6C5E847BA4D3BBB4F532</string>
+			<key>IDESourceControlWCCName</key>
+			<string>ObjQREncoder</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/src/QREncoderOSXTests/Info.plist
+++ b/src/QREncoderOSXTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>FoOTOo.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/src/QREncoderOSX_Prefix.pch
+++ b/src/QREncoderOSX_Prefix.pch
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2009
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef __OBJC__
+    #import <Foundation/Foundation.h>
+    #import <Cocoa/Cocoa.h>
+#endif


### PR DESCRIPTION
I failed to bundle OS X demo app with iOS demo due to this error [-fobj-arc is not supported on platforms using the legacy runtime](http://www.cocoanetics.com/2013/10/fobj-arc-is-not-supported-on-platforms-using-the-legacy-runtime/). 
So I tested OS X library with a separate OS X demo app and works. But seems `[imageView layer].magnificationFilter = kCAFilterNearest;` not working on OS X even if I set image scaling to the NSImageView. It works on iOS. I will find this out in future if I have enough time.
![fd26065c-520d-4632-bb76-d2f7bff782bd](https://cloud.githubusercontent.com/assets/4608342/5280709/b5ade364-7b2f-11e4-8757-614e3b951411.jpg)
Remember to update this repo's README.md file and describe with OS X support!
Thanks! 
